### PR TITLE
[IK-146] 팔로잉 멤버 목록 조회 통합 테스트

### DIFF
--- a/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
@@ -1,4 +1,4 @@
-package com.kdt.instakyuram.follow.follow;
+package com.kdt.instakyuram.follow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
@@ -31,7 +31,7 @@ public class IntegrationTest {
 	@DisplayName("팔로잉 목록 조회 테스트")
 	void testFollowing() {
 		//given
-		List<Member> members = this.getDemoMembers();
+		List<Member> members = getDemoMembers();
 
 		Member member = members.get(0);
 		Member targetA = members.get(1);

--- a/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/follow/IntegrationTest.java
@@ -6,30 +6,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import javax.persistence.EntityManager;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.instakyuram.follow.domain.Follow;
-import com.kdt.instakyuram.follow.domain.FollowRepository;
 import com.kdt.instakyuram.follow.service.FollowService;
 import com.kdt.instakyuram.member.domain.Member;
-import com.kdt.instakyuram.member.domain.MemberRepository;
 
 @SpringBootTest
 public class IntegrationTest {
 
 	@Autowired
+	EntityManager entityManager;
+	@Autowired
 	private FollowService followService;
 
-	@Autowired
-	private FollowRepository followRepository;
-
-	@Autowired
-	private MemberRepository memberRepository;
-
 	@Test
+	@Transactional
 	@DisplayName("팔로잉 목록 조회 테스트")
 	void testFollowing() {
 		//given
@@ -39,27 +37,28 @@ public class IntegrationTest {
 		Member targetA = members.get(1);
 		Member targetB = members.get(2);
 
-		List<Follow> followings = followRepository.saveAll(List.of(
-			Follow.builder()
-				.memberId(member.getId())
-				.targetId(targetA.getId())
-				.build(),
+		entityManager.persist(Follow.builder()
+			.memberId(member.getId())
+			.targetId(targetA.getId())
+			.build());
 
-			Follow.builder()
-				.memberId(member.getId())
-				.targetId(targetB.getId())
-				.build()
-		));
+		entityManager.persist(Follow.builder()
+			.memberId(member.getId())
+			.targetId(targetB.getId())
+			.build());
+
+		List<Long> expectedFollowingIds = List.of(targetA.getId(), targetB.getId());
 
 		//when
 		List<Long> followingIds = followService.findByFollowingIds(member.getId());
 
 		//then
-		assertThat(followingIds.size()).isEqualTo(followings.size());
+		assertThat(followingIds.size()).isEqualTo(expectedFollowingIds.size());
 		assertThat(followingIds).contains(targetA.getId(), targetB.getId());
 	}
 
-	private List<Member> getDemoMembers() {
+	@Transactional
+	public List<Member> getDemoMembers() {
 
 		List<Member> follwings = new ArrayList<>();
 
@@ -70,17 +69,17 @@ public class IntegrationTest {
 
 		IntStream.range(1, 5).forEach(
 			number -> {
-				Member persistedMember = memberRepository.save(
-					Member.builder()
-						.email((name + number) + emailPostfix)
-						.password(password)
-						.username(name + number)
-						.phoneNumber(phoneNumber)
-						.name(name)
-						.build()
-				);
+				Member member = Member.builder()
+					.email((name + number) + emailPostfix)
+					.password(password)
+					.username(name + number)
+					.phoneNumber(phoneNumber)
+					.name(name)
+					.build();
 
-				follwings.add(persistedMember);
+				entityManager.persist(member);
+
+				follwings.add(member);
 			}
 		);
 

--- a/src/test/java/com/kdt/instakyuram/follow/domain/FollowRepositoryTest.java
+++ b/src/test/java/com/kdt/instakyuram/follow/domain/FollowRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.kdt.instakyuram.follow.follow.domain;
+package com.kdt.instakyuram.follow.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/kdt/instakyuram/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/kdt/instakyuram/follow/service/FollowServiceTest.java
@@ -1,4 +1,4 @@
-package com.kdt.instakyuram.follow.follow.service;
+package com.kdt.instakyuram.follow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/kdt/instakyuram/member/IntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/IntegrationTest.java
@@ -1,0 +1,116 @@
+package com.kdt.instakyuram.member;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.LongStream;
+
+import javax.persistence.EntityManager;
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.instakyuram.follow.domain.Follow;
+import com.kdt.instakyuram.member.domain.Member;
+import com.kdt.instakyuram.member.dto.MemberConverter;
+import com.kdt.instakyuram.member.dto.MemberResponse;
+import com.kdt.instakyuram.member.service.PostGiver;
+
+@SpringBootTest
+public class IntegrationTest {
+
+	@Autowired
+	EntityManager entityManager;
+	@Autowired
+	PostGiver postGiver;
+
+	@Autowired
+	MemberConverter memberConverter;
+
+	@Test
+	@DisplayName("의존성 테스트")
+	void testDependencyInjection() {
+		//given
+		//when
+		//then
+		Assertions.assertThat(entityManager).isNotNull();
+		Assertions.assertThat(postGiver).isNotNull();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("팔로잉 목록 멤버를 조회")
+	void testFindAllFollowing() {
+		//given
+		List<Member> members = getDemoMembers();
+
+		Member member = members.get(0);
+		Member targetA = members.get(1);
+		Member targetB = members.get(2);
+
+		entityManager.persist(Follow.builder()
+			.memberId(member.getId())
+			.targetId(targetA.getId())
+			.build());
+
+		entityManager.persist(Follow.builder()
+			.memberId(member.getId())
+			.targetId(targetB.getId())
+			.build());
+
+		List<MemberResponse> expectedFollowings = List.of(targetA, targetB).stream()
+			.map(memberConverter::toMemberResponse)
+			.toList();
+
+		//when
+		List<MemberResponse> followings = postGiver.findAllFollowing(member.getId());
+
+		//then
+		Assertions.assertThat(followings.size()).isEqualTo(expectedFollowings.size());
+
+		AtomicInteger index = new AtomicInteger();
+
+		followings.forEach(following -> {
+			MatcherAssert.assertThat(
+				following,
+				Matchers.samePropertyValuesAs(expectedFollowings.get(index.getAndIncrement()))
+			);
+		});
+	}
+
+	@Transactional
+	public List<Member> getDemoMembers() {
+
+		List<Member> members = new ArrayList<>();
+
+		String name = "programmers";
+		String password = "password";
+		String phoneNumber = "01012345678";
+		String emailPostfix = "@programmers.co.kr";
+
+		LongStream.range(1, 5).forEach(
+			number -> {
+				Member member = Member.builder()
+					.email((name + number) + emailPostfix)
+					.password(password)
+					.username(name + number)
+					.phoneNumber(phoneNumber)
+					.name(name)
+					.build();
+
+				entityManager.persist(member);
+
+				members.add(member);
+			}
+		);
+
+		return members;
+	}
+
+}

--- a/src/test/java/com/kdt/instakyuram/member/IntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/IntegrationTest.java
@@ -34,16 +34,6 @@ public class IntegrationTest {
 	MemberConverter memberConverter;
 
 	@Test
-	@DisplayName("의존성 테스트")
-	void testDependencyInjection() {
-		//given
-		//when
-		//then
-		Assertions.assertThat(entityManager).isNotNull();
-		Assertions.assertThat(postGiver).isNotNull();
-	}
-
-	@Test
 	@Transactional
 	@DisplayName("팔로잉 목록 멤버를 조회")
 	void testFindAllFollowing() {


### PR DESCRIPTION
## ✅  작업 단위

- [IK-146] 팔로잉 멤버 목록 조회 통합 테스트

## 🤔 고민 했던 부분

- 해당 도메인 통합테스트에서 제공하는 모의 데이터는 EntityManager를 통해 영속화를 시키고 테스트를 진행했습니다. 
- @Autowired 통해 다른 도메인 레포를 따로 두지 않는 것이 개인적으로 좋은 것 같아요.
- 그 이유는 해당 도메인에 대해 통합 테스트를 하는데 다른 도메인 레포를 가지고 온 거 서부터가 레이어드 아키텍처가 깨져보일 수 있기 때문입니다.
- 실제 서비스는 레이어드로 가져가지만  테스트 코드 또한 레이어드 기반으로 테스트 되어야 한다고 생각합니 🥕 !

## 🔊 HELP !!
- 

[IK-146]: https://insta-kkyu.atlassian.net/browse/IK-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ