### PR TITLE
[IK-25] 댓글 작성, 좋아요, 좋아요 취소, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -3,5 +3,5 @@ package com.kdt.instakyuram.comment.controller;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class CommentController {
+public class CommentRestController {
 }

--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -1,5 +1,6 @@
 package com.kdt.instakyuram.comment.controller;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +22,21 @@ public class CommentRestController {
 	}
 
 	@PostMapping
-	public ApiResponse<CommentResponse> create(@RequestBody CommentRequest request) {
+	public ApiResponse<CommentResponse> create(@RequestBody CommentRequest.CreateRequest request) {
 		CommentResponse commentResponse = commentService.create(
 			request.postId(), request.memberId(), request.content()
+		);
+
+		return new ApiResponse<>(commentResponse);
+	}
+
+	@PostMapping("/{id}/like")
+	public ApiResponse<CommentResponse.LikeResponse> like(
+		@PathVariable Long id,
+		@RequestBody CommentRequest.LikeRequest request
+	) {
+		CommentResponse.LikeResponse commentResponse = commentService.like(
+			id, request.memberId()
 		);
 
 		return new ApiResponse<>(commentResponse);

--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -1,5 +1,6 @@
 package com.kdt.instakyuram.comment.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +29,14 @@ public class CommentRestController {
 		);
 
 		return new ApiResponse<>(commentResponse);
+	}
+
+	@DeleteMapping("/{id}")
+	public void delete(
+		@PathVariable Long id,
+		@RequestBody CommentRequest.DeleteRequest request
+	) {
+		commentService.delete(id, request.memberId());
 	}
 
 	@PostMapping("/{id}/like")

--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -1,7 +1,31 @@
 package com.kdt.instakyuram.comment.controller;
 
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt.instakyuram.comment.dto.CommentRequest;
+import com.kdt.instakyuram.comment.dto.CommentResponse;
+import com.kdt.instakyuram.comment.service.CommentService;
+import com.kdt.instakyuram.common.ApiResponse;
+
 @RestController
+@RequestMapping("/api/comments")
 public class CommentRestController {
+
+	private final CommentService commentService;
+
+	public CommentRestController(CommentService commentService) {
+		this.commentService = commentService;
+	}
+
+	@PostMapping
+	public ApiResponse<CommentResponse> create(@RequestBody CommentRequest request) {
+		CommentResponse commentResponse = commentService.create(
+			request.postId(), request.memberId(), request.content()
+		);
+
+		return new ApiResponse<>(commentResponse);
+	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -41,4 +41,16 @@ public class CommentRestController {
 
 		return new ApiResponse<>(commentResponse);
 	}
+
+	@PostMapping("{id}/unlike")
+	public ApiResponse<CommentResponse.LikeResponse> unlike(
+		@PathVariable Long id,
+		@RequestBody CommentRequest.LikeRequest request
+	) {
+		CommentResponse.LikeResponse commentResponse = commentService.unlike(
+			id, request.memberId()
+		);
+
+		return new ApiResponse<>(commentResponse);
+	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/domain/Comment.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/Comment.java
@@ -36,6 +36,10 @@ public class Comment {
 
 	protected Comment() {/*no-op*/}
 
+	public Comment(Long id) {
+		this(id, null, null, null);
+	}
+
 	public Comment(String content, Post post, Member member) {
 		this(null, content, post, member);
 	}

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentLike.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentLike.java
@@ -30,6 +30,10 @@ public class CommentLike {
 
 	protected CommentLike() {/*no-op*/}
 
+	public CommentLike(Comment comment, Member member) {
+		this(null, comment, member);
+	}
+
 	public CommentLike(Long id, Comment comment, Member member) {
 		this.id = id;
 		this.comment = comment;

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
@@ -1,5 +1,7 @@
 package com.kdt.instakyuram.comment.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +11,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 
 	@Query("SELECT count(cl.id) FROM CommentLike cl")
 	int countByCommentId(Long commentId);
+
+	@Query("SELECT cl FROM CommentLike cl WHERE cl.comment.id = :commentId AND cl.member.id = :memberId")
+	Optional<CommentLike> findByCommentIdAndMemberId(Long commentId, Long memberId);
 }

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
@@ -1,6 +1,12 @@
 package com.kdt.instakyuram.comment.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+	boolean existsCommentLikeByCommentIdAndMemberId(Long commentId, Long memberId);
+
+	@Query("SELECT count(cl.id) FROM CommentLike cl")
+	int countByCommentId(Long commentId);
 }

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentLikeRepository.java
@@ -1,5 +1,6 @@
 package com.kdt.instakyuram.comment.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
 
 	@Query("SELECT cl FROM CommentLike cl WHERE cl.comment.id = :commentId AND cl.member.id = :memberId")
 	Optional<CommentLike> findByCommentIdAndMemberId(Long commentId, Long memberId);
+
+	@Query("SELECT cl FROM CommentLike cl WHERE cl.comment.id = :commentId")
+	List<CommentLike> findByCommentId(Long commentId);
 }

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepository.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.kdt.instakyuram.comment.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,4 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@Query("SELECT c FROM Comment c JOIN FETCH c.member m WHERE c.post.id = :postId")
 	List<Comment> findAllByPostId(Long postId);
+
+	@Query("SELECT c FROM Comment c WHERE c.id = :id AND c.member.id = :memberId")
+	Optional<Comment> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentConverter.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentConverter.java
@@ -3,6 +3,7 @@ package com.kdt.instakyuram.comment.dto;
 import org.springframework.stereotype.Component;
 
 import com.kdt.instakyuram.comment.domain.Comment;
+import com.kdt.instakyuram.comment.domain.CommentLike;
 import com.kdt.instakyuram.member.domain.Member;
 import com.kdt.instakyuram.member.dto.MemberResponse;
 import com.kdt.instakyuram.post.domain.Post;
@@ -23,6 +24,15 @@ public class CommentConverter {
 			comment.getContent(),
 			memberResponse
 		);
+	}
+
+	public CommentLike toCommentLike(CommentResponse commentResponse, MemberResponse memberResponse) {
+		Comment comment = new Comment(commentResponse.id());
+		Member member = Member.builder()
+			.id(memberResponse.id())
+			.build();
+
+		return new CommentLike(comment, member);
 	}
 
 	private Member toMember(MemberResponse memberResponse) {

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
@@ -1,4 +1,4 @@
 package com.kdt.instakyuram.comment.dto;
 
-public class CommentRequest {
+public record CommentRequest(Long postId, Long memberId, String content) {
 }

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
@@ -5,4 +5,6 @@ public record CommentRequest() {
 	public record CreateRequest(Long postId, Long memberId, String content) {}
 
 	public record LikeRequest(Long memberId) {}
+
+	public record DeleteRequest(Long memberId) {}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
@@ -1,4 +1,8 @@
 package com.kdt.instakyuram.comment.dto;
 
-public record CommentRequest(Long postId, Long memberId, String content) {
+public record CommentRequest() {
+
+	public record CreateRequest(Long postId, Long memberId, String content) {}
+
+	public record LikeRequest(Long memberId) {}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentResponse.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentResponse.java
@@ -6,4 +6,10 @@ import lombok.Builder;
 
 @Builder
 public record CommentResponse(Long id, String content, MemberResponse member) {
+
+	public record LikeResponse(
+		Long id,
+		int likes,
+		boolean isLiked
+	) {}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentGiver.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentGiver.java
@@ -6,4 +6,6 @@ import com.kdt.instakyuram.comment.dto.CommentResponse;
 
 public interface CommentGiver {
 	List<CommentResponse> findByPostId(Long postId);
+
+	void delete(Long id);
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
@@ -1,5 +1,7 @@
 package com.kdt.instakyuram.comment.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.kdt.instakyuram.comment.domain.CommentLike;
@@ -44,5 +46,10 @@ public class CommentLikeService {
 				return new CommentResponse.LikeResponse(id, likes, false);
 			})
 			.orElseThrow(() -> new IllegalArgumentException("이미 좋아요 취소 상태 입니다."));
+	}
+
+	public void delete(Long commentId) {
+		List<CommentLike> commentLikes = commentLikeRepository.findByCommentId(commentId);
+		commentLikeRepository.deleteAll(commentLikes);
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
@@ -32,4 +32,17 @@ public class CommentLikeService {
 
 		return new CommentResponse.LikeResponse(comment.id(), likes, true);
 	}
+
+	public CommentResponse.LikeResponse unlike(Long id, Long memberId) {
+		return commentLikeRepository.findByCommentIdAndMemberId(id, memberId)
+			.map(commentLike -> {
+				commentLikeRepository.delete(commentLike);
+
+				// 해당 댓글의 좋아요 개수까지 포함해서 리턴
+				int likes = commentLikeRepository.countByCommentId(id);
+
+				return new CommentResponse.LikeResponse(id, likes, false);
+			})
+			.orElseThrow(() -> new IllegalArgumentException("이미 좋아요 취소 상태 입니다."));
+	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentLikeService.java
@@ -2,6 +2,34 @@ package com.kdt.instakyuram.comment.service;
 
 import org.springframework.stereotype.Service;
 
+import com.kdt.instakyuram.comment.domain.CommentLike;
+import com.kdt.instakyuram.comment.domain.CommentLikeRepository;
+import com.kdt.instakyuram.comment.dto.CommentConverter;
+import com.kdt.instakyuram.comment.dto.CommentResponse;
+import com.kdt.instakyuram.member.dto.MemberResponse;
+
 @Service
 public class CommentLikeService {
+
+	private final CommentLikeRepository commentLikeRepository;
+	private final CommentConverter commentConverter;
+
+	public CommentLikeService(CommentLikeRepository commentLikeRepository, CommentConverter commentConverter) {
+		this.commentLikeRepository = commentLikeRepository;
+		this.commentConverter = commentConverter;
+	}
+
+	public CommentResponse.LikeResponse like(CommentResponse comment, MemberResponse member) {
+		if (commentLikeRepository.existsCommentLikeByCommentIdAndMemberId(comment.id(), member.id())) {
+			throw new IllegalArgumentException("이미 좋아요 상태 입니다.");
+		}
+
+		CommentLike commentLike = commentConverter.toCommentLike(comment, member);
+		commentLikeRepository.save(commentLike);
+
+		// 해당 댓글의 좋아요 개수까지 포함해서 리턴
+		int likes = commentLikeRepository.countByCommentId(comment.id());
+
+		return new CommentResponse.LikeResponse(comment.id(), likes, true);
+	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -1,7 +1,5 @@
 package com.kdt.instakyuram.comment.service;
 
-import static java.util.stream.Collectors.*;
-
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -28,7 +26,7 @@ public class CommentService implements CommentGiver {
 	}
 
 	@Transactional
-	public CommentResponse create(Long memberId, Long postId, String content) {
+	public CommentResponse create(Long postId, Long memberId, String content) {
 		MemberResponse member = memberGiver.findById(memberId);
 		Comment comment = commentConverter.toComment(member, postId, content);
 		Comment savedComment = commentRepository.save(comment);
@@ -44,6 +42,6 @@ public class CommentService implements CommentGiver {
 	public List<CommentResponse> findByPostId(Long postId) {
 		return commentRepository.findAllByPostId(postId).stream()
 			.map(commentConverter::toResponse)
-			.collect(toList());
+			.toList();
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -47,6 +47,17 @@ public class CommentService implements CommentGiver {
 	}
 
 	@Transactional
+	public void delete(Long id, Long memberId) {
+		commentRepository.findByIdAndMemberId(id, memberId)
+			.map(comment -> {
+				commentLikeService.delete(id);
+				commentRepository.delete(comment);
+				return true;
+			})
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+	}
+
+	@Transactional
 	public CommentResponse.LikeResponse like(Long id, Long memberId) {
 		return commentRepository.findById(id)
 			.map(comment -> {

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -58,10 +58,19 @@ public class CommentService implements CommentGiver {
 			.orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
 	}
 
+	@Transactional
+	public CommentResponse.LikeResponse unlike(Long id, Long memberId) {
+		return commentRepository.findById(id)
+			.map(comment -> commentLikeService.unlike(id, memberId))
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+	}
+
 	@Override
 	public List<CommentResponse> findByPostId(Long postId) {
 		return commentRepository.findAllByPostId(postId).stream()
 			.map(commentConverter::toResponse)
 			.toList();
 	}
+
+
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -83,5 +83,15 @@ public class CommentService implements CommentGiver {
 			.toList();
 	}
 
+	@Override
+	public void delete(Long id) {
+		commentRepository.findById(id)
+			.map(comment -> {
+				commentLikeService.delete(id);
+				commentRepository.delete(comment);
+				return true;
+			})
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+	}
 
 }


### PR DESCRIPTION
## ✅  작업 단위

- [[IK-25] refactor: 댓글 컨트롤러명 변경, Service 리팩토링](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/659d45a55591bca95a37bdc9cd5fa9fa69d59dc6)
  - 컨트롤러명 변경, 이전 혜빈님 리뷰 사항 적용, 소소한 수정
- [[IK-25] feat: 댓글 작성 기능 구현 완료](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/d31bf34ed10e2519e2fab27e6c6fbc07b33fa94c)
  - Service 메서드는 이미 구현한 상태라 Controller 연결
- [[IK-25] feat: 댓글 좋아요 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/79af349d2f174630ffe0cd7075ca13f0d4085ce1)
  - 해당 댓글 좋아요 등록 후 반환 **(댓글 ID, 좋아요 상태, 좋아요 총 갯수)**
- [[IK-25] feat: 댓글 좋아요 취소 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/532ecaf5fe68be84eb70671e772e898d9913657f)
- [[IK-25] feat: 댓글 삭제 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/e7b86ed6867decd8b37cfd9fe486106d3d5fd781)
- [[IK-25] feat: 댓글 삭제 기능(From 게시글) 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/52f860c58d4e67522d56b37be99cf04ae6d7a94a)
  - Post 쪽에서 검증 됬다고 가정하고 id 만 받아서 그대로 삭제하도록 구현
  - CommentGiver 에 추가

## 🤔 고민 했던 부분

### [[IK-25] feat: 댓글 삭제 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/e7b86ed6867decd8b37cfd9fe486106d3d5fd781)
이 녀석은 안쓰게 될 것 같지만, 혹시 몰라 구현해 두었습니다.

### [[IK-25] feat: 댓글 좋아요 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/79af349d2f174630ffe0cd7075ca13f0d4085ce1)
좋아요 눌렀을 때, 리턴 객체를 좋아요 수랑, 좋아요 상태만 반환되도록 했습니다.
```java
public record LikeResponse(
  Long id,
  int likes,
  boolean isLiked
) {}
```
이 부분은 프론트 먼저 구현하고 했어야 됬다고 느꼈습니다.
댓글 좋아요 눌렀을때 바뀌는 값이 좋아요 상태와 총 갯수 → 비동기로 통신으로 해당 값만 받아와서 바꾸면 되지 않나 가정하고 작성했지만,
프론트에서 값만 바꾼다는게 되는지 안되는지도 모르는데 했던 고민조차 무의미 했다는 생각이 드네요.

### [[IK-25] feat: 댓글 삭제 기능(From 게시글) 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/52f860c58d4e67522d56b37be99cf04ae6d7a94a)
이미 Post에서 댓글을 조회해서 검증을 했는데, 또 Comment에서 조회를 할 필요가 있을까? 라는 고민을 했습니다만, 일단 놔뒀습니다.


## 🔊 HELP !!

### [[IK-25] feat: 댓글 좋아요 기능 구현](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/79af349d2f174630ffe0cd7075ca13f0d4085ce1)
- commentLikeService 부분에 Id만 넘겨주는게 맞겠죠? 👾
  ```java
  @Transactional
	public CommentResponse.LikeResponse like(Long id, Long memberId) {
		return commentRepository.findById(id)
			.map(comment -> {
				MemberResponse memberResponse = memberGiver.findById(memberId);
				CommentResponse commentResponse = commentConverter.toResponse(comment);

				return commentLikeService.like(commentResponse, memberResponse);
			})
			.orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
	}
  ```
  뭔가 만든 객체가 아까워서 넣었는데, 지금 보니까 아닌거 같네요.

[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-25]: https://insta-kkyu.atlassian.net/browse/IK-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ