### PR TITLE
[IK-35] feat : 사용자가 게시글 좋아요 및 좋아요 취소 기능 구현

### DIFF
--- a/src/main/java/com/kdt/instakyuram/post/controller/PostRestController.java
+++ b/src/main/java/com/kdt/instakyuram/post/controller/PostRestController.java
@@ -40,12 +40,12 @@ public class PostRestController {
 		return new ApiResponse<>(postService.findAll(memberId));
 	}
 
-	@PostMapping("/likes/{id}/like")
+	@PostMapping("/{id}/like")
 	public ApiResponse<PostLikeResponse> like(@PathVariable Long id, @RequestBody PostLikeRequest postLikeRequest) {
 		return new ApiResponse<>(postService.like(id, postLikeRequest.memberId()));
 	}
 
-	@PostMapping("/likes/{id}/unlike")
+	@PostMapping("/{id}/unlike")
 	public ApiResponse<PostLikeResponse> unlike(@PathVariable Long id,
 		@RequestBody PostLikeRequest postLikeRequest) {
 		return new ApiResponse<>(postService.unlike(id, postLikeRequest.memberId()));

--- a/src/main/java/com/kdt/instakyuram/post/controller/PostRestController.java
+++ b/src/main/java/com/kdt/instakyuram/post/controller/PostRestController.java
@@ -5,10 +5,13 @@ import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kdt.instakyuram.common.ApiResponse;
+import com.kdt.instakyuram.post.dto.PostLikeRequest;
+import com.kdt.instakyuram.post.dto.PostLikeResponse;
 import com.kdt.instakyuram.post.dto.PostRequest;
 import com.kdt.instakyuram.post.dto.PostResponse;
 import com.kdt.instakyuram.post.service.PostService;
@@ -25,20 +28,27 @@ public class PostRestController {
 
 	@PostMapping
 	public ApiResponse<PostResponse.CreateResponse> posting(
-		PostRequest.CreateRequest request
+		@RequestBody PostRequest.CreateRequest request
 	) {
-		return new ApiResponse(
-			postService.create(
-				request.memberId(), request.content(), request.postImages()
-			)
-		);
+		return new ApiResponse<>(postService.create(
+			request.memberId(), request.content(), request.postImages()
+		));
 	}
 
 	@GetMapping("/{memberId}")
 	public ApiResponse<List<PostResponse.FindAllResponse>> findAll(@PathVariable Long memberId) {
-		return new ApiResponse(
-			postService.findAll(memberId)
-		);
+		return new ApiResponse<>(postService.findAll(memberId));
+	}
+
+	@PostMapping("/likes/{id}/like")
+	public ApiResponse<PostLikeResponse> like(@PathVariable Long id, @RequestBody PostLikeRequest postLikeRequest) {
+		return new ApiResponse<>(postService.like(id, postLikeRequest.memberId()));
+	}
+
+	@PostMapping("/likes/{id}/unlike")
+	public ApiResponse<PostLikeResponse> unlike(@PathVariable Long id,
+		@RequestBody PostLikeRequest postLikeRequest) {
+		return new ApiResponse<>(postService.unlike(id, postLikeRequest.memberId()));
 	}
 
 }

--- a/src/main/java/com/kdt/instakyuram/post/domain/PostLikeRepository.java
+++ b/src/main/java/com/kdt/instakyuram/post/domain/PostLikeRepository.java
@@ -1,6 +1,7 @@
 package com.kdt.instakyuram.post.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,8 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 	List<PostLike> findByPostId(Long postId);
 
 	int countByPostId(Long postId);
+
+	Optional<PostLike> findByPostIdAndMemberId(Long postId, Long memberId);
+
+	boolean existsPostLikeByPostIdAndMemberId(Long postId, Long memberId);
 }

--- a/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
+++ b/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
@@ -37,7 +37,7 @@ public class PostConverter {
 
 	public PostImage toPostImage(MultipartFile file, Post post) {
 		String originalFileName = file.getOriginalFilename();
-		String serverFileName = UUID.randomUUID().toString() + extractExt(originalFileName);
+		String serverFileName = UUID.randomUUID() + extractExt(originalFileName);
 
 		return PostImage.builder()
 			.post(post)
@@ -56,13 +56,12 @@ public class PostConverter {
 
 	public PostResponse.FindAllResponse toDetailResponse(MemberResponse memberResponse, Post post,
 		List<PostImageResponse> postImageResponse, List<CommentResponse> commentResponse,
-		List<PostLikeResponse> postLikeResponse, int totalPostLike) {
+		int totalPostLike) {
 		return PostResponse.FindAllResponse.builder()
 			.content(post.getContent())
 			.member(memberResponse)
 			.postImageResponse(postImageResponse)
 			.commentResponse(commentResponse)
-			.postLikeResponse(postLikeResponse)
 			.totalPostLike(totalPostLike)
 			.build();
 

--- a/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
+++ b/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
@@ -48,6 +48,12 @@ public class PostConverter {
 			.build();
 	}
 
+	private static String extractExt(String originalFileName) {
+		return originalFileName.substring(
+			originalFileName.lastIndexOf(".")
+		);
+	}
+
 	public PostResponse.FindAllResponse toDetailResponse(MemberResponse memberResponse, Post post,
 		List<PostImageResponse> postImageResponse, List<CommentResponse> commentResponse,
 		List<PostLikeResponse> postLikeResponse, int totalPostLike) {
@@ -70,12 +76,6 @@ public class PostConverter {
 			.build();
 	}
 
-	private static String extractExt(String originalFileName) {
-		return originalFileName.substring(
-			originalFileName.lastIndexOf(".")
-		);
-	}
-
 	public PostImageResponse toPostImageResponse(PostImage postImage) {
 		return PostImageResponse.builder()
 			.id(postImage.getId())
@@ -86,10 +86,14 @@ public class PostConverter {
 			.build();
 	}
 
-	public PostLikeResponse toPostLikeResponse(PostLike postLike) {
-		return PostLikeResponse.builder()
-			.id(postLike.getId())
-			.memberResponse(toMemberResponse(postLike.getMember()))
+	public PostLike toPostLike(PostResponse postResponse, MemberResponse memberResponse) {
+		return PostLike.builder()
+			.post(Post.builder()
+				.id(postResponse.id())
+				.build())
+			.member(Member.builder()
+				.id(memberResponse.id())
+				.build())
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
+++ b/src/main/java/com/kdt/instakyuram/post/dto/PostConverter.java
@@ -86,13 +86,16 @@ public class PostConverter {
 	}
 
 	public PostLike toPostLike(PostResponse postResponse, MemberResponse memberResponse) {
+		Post post = Post.builder()
+			.id(postResponse.id())
+			.build();
+		Member member = Member.builder()
+			.id(memberResponse.id())
+			.build();
+
 		return PostLike.builder()
-			.post(Post.builder()
-				.id(postResponse.id())
-				.build())
-			.member(Member.builder()
-				.id(memberResponse.id())
-				.build())
+			.post(post)
+			.member(member)
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/post/dto/PostLikeRequest.java
+++ b/src/main/java/com/kdt/instakyuram/post/dto/PostLikeRequest.java
@@ -1,0 +1,4 @@
+package com.kdt.instakyuram.post.dto;
+
+public record PostLikeRequest(Long memberId) {
+}

--- a/src/main/java/com/kdt/instakyuram/post/dto/PostLikeResponse.java
+++ b/src/main/java/com/kdt/instakyuram/post/dto/PostLikeResponse.java
@@ -1,9 +1,8 @@
 package com.kdt.instakyuram.post.dto;
 
-import com.kdt.instakyuram.member.dto.MemberResponse;
-
 import lombok.Builder;
 
 @Builder
-public record PostLikeResponse(Long id, MemberResponse memberResponse) {
+public record PostLikeResponse(Long postId, int likes, boolean isLiked) {
+
 }

--- a/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
@@ -1,9 +1,6 @@
 package com.kdt.instakyuram.post.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.instakyuram.member.dto.MemberResponse;
 import com.kdt.instakyuram.post.domain.PostLikeRepository;
@@ -42,9 +39,8 @@ public class PostLikeService {
 
 		postLikeRepository.save(postConverter.toPostLike(post, member));
 		int likes = postLikeRepository.countByPostId(post.id());
-		boolean isLiked = postLikeRepository.existsPostLikeByPostIdAndMemberId(post.id(), member.id());
 
-		return new PostLikeResponse(post.id(), likes, isLiked);
+		return new PostLikeResponse(post.id(), likes, true);
 	}
 
 	public PostLikeResponse unlike(PostResponse post, MemberResponse member) {

--- a/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
@@ -20,15 +20,6 @@ public class PostLikeService {
 		this.postConverter = postConverter;
 	}
 
-	public List<PostLikeResponse> findByPostId(Long postId) {
-		return postLikeRepository.findByPostId(postId).stream()
-			.map(postLike -> PostLikeResponse.builder()
-				.postId(postId)
-				.likes(postLikeRepository.countByPostId(postId))
-				.build())
-			.toList();
-	}
-
 	public int countByPostId(Long postId) {
 		return postLikeRepository.countByPostId(postId);
 	}

--- a/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
+++ b/src/main/java/com/kdt/instakyuram/post/service/PostLikeService.java
@@ -1,6 +1,7 @@
 package com.kdt.instakyuram.post.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.instakyuram.member.dto.MemberResponse;
 import com.kdt.instakyuram.post.domain.PostLikeRepository;
@@ -32,6 +33,7 @@ public class PostLikeService {
 		return postLikeRepository.countByPostId(postId);
 	}
 
+	@Transactional
 	public PostLikeResponse like(PostResponse post, MemberResponse member) {
 		if (postLikeRepository.existsPostLikeByPostIdAndMemberId(post.id(), member.id())) {
 			throw new IllegalArgumentException("이미 좋아요 상태입니다.");
@@ -43,6 +45,7 @@ public class PostLikeService {
 		return new PostLikeResponse(post.id(), likes, true);
 	}
 
+	@Transactional
 	public PostLikeResponse unlike(PostResponse post, MemberResponse member) {
 		return postLikeRepository.findByPostIdAndMemberId(post.id(), member.id())
 			.map(postLike -> {

--- a/src/main/java/com/kdt/instakyuram/post/service/PostService.java
+++ b/src/main/java/com/kdt/instakyuram/post/service/PostService.java
@@ -17,8 +17,8 @@ import com.kdt.instakyuram.post.dto.PostConverter;
 import com.kdt.instakyuram.post.dto.PostLikeResponse;
 import com.kdt.instakyuram.post.dto.PostResponse;
 
-@Transactional(readOnly = true)
 @Service
+@Transactional(readOnly = true)
 public class PostService {
 
 	private final PostRepository postRepository;
@@ -69,7 +69,6 @@ public class PostService {
 					post,
 					postImageService.findByPostId(post.getId()),
 					commentGiver.findByPostId(post.getId()),
-					postLikeService.findByPostId(post.getId()),
 					postLikeService.countByPostId(post.getId())
 				)
 			)

--- a/src/main/java/com/kdt/instakyuram/post/service/PostService.java
+++ b/src/main/java/com/kdt/instakyuram/post/service/PostService.java
@@ -7,11 +7,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.kdt.instakyuram.comment.service.CommentGiver;
+import com.kdt.instakyuram.exception.NotFoundException;
 import com.kdt.instakyuram.member.domain.Member;
+import com.kdt.instakyuram.member.dto.MemberResponse;
 import com.kdt.instakyuram.member.service.MemberGiver;
 import com.kdt.instakyuram.post.domain.Post;
 import com.kdt.instakyuram.post.domain.PostRepository;
 import com.kdt.instakyuram.post.dto.PostConverter;
+import com.kdt.instakyuram.post.dto.PostLikeResponse;
 import com.kdt.instakyuram.post.dto.PostResponse;
 
 @Transactional(readOnly = true)
@@ -22,9 +25,7 @@ public class PostService {
 	private final PostConverter postConverter;
 	private final MemberGiver memberGiver;
 	private final PostImageService postImageService;
-
 	private final CommentGiver commentGiver;
-
 	private final PostLikeService postLikeService;
 
 	public PostService(PostRepository postRepository, PostConverter postConverter,
@@ -75,4 +76,27 @@ public class PostService {
 			.toList();
 	}
 
+	@Transactional
+	public PostLikeResponse like(Long postId, Long memberId) {
+		return postRepository.findById(postId)
+			.map(post -> {
+				MemberResponse memberResponse = memberGiver.findById(memberId);
+				PostResponse postResponse = postConverter.toResponse(post);
+
+				return postLikeService.like(postResponse, memberResponse);
+			})
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
+	}
+
+	@Transactional
+	public PostLikeResponse unlike(Long postId, Long memberId) {
+		return postRepository.findById(postId)
+			.map(post -> {
+				MemberResponse memberResponse = memberGiver.findById(memberId);
+				PostResponse postResponse = postConverter.toResponse(post);
+
+				return postLikeService.unlike(postResponse, memberResponse);
+			})
+			.orElseThrow(() -> new NotFoundException("존재하지 않는 게시글입니다."));
+	}
 }


### PR DESCRIPTION
## ✅  작업 단위
### Like - 사용자가 좋아요를 한다.
![image](https://user-images.githubusercontent.com/35947674/174724606-89d056b7-7b24-433b-877e-962348e0419f.png)

### Unlike - 사용자가 좋아요를 취소한다.
![image](https://user-images.githubusercontent.com/35947674/174724724-67ae18cf-34a0-4f33-a36f-fda80689b59e.png)

- 동운님이 구현하신 comment like의 형태와 동일하게 구현하였습니다.


## 🤔 고민 했던 부분

## 🔊 HELP !!
- PostLikeService의 Transactional 을 가져갈지는 형욱님과 동운님의 의견 주시면 반영하겠습니당 의견 부탁드립니다 ! 
   - 일단 저는 PostLike까지 있어야겠나 싶지만 한편으로는 저희가 알 수 없는 오류가 날 수도 있으니 ,,? 달아주는게 더 안전하지 않을까 하는 의견입니당 ! 
   - 현재 PostLikeService의 Transactional 어노테이션 빼놨습니다.
- url은 인스타그램의 실제 url과 동일하게 가져갔습니다. likes가 불필요하다 생각하시면 말씀해주세용 