### PR TITLE
[IK-217] develop branch 수정

### DIFF
--- a/src/main/java/com/kdt/instakyuram/config/JpaAuditConfig.java
+++ b/src/main/java/com/kdt/instakyuram/config/JpaAuditConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -20,7 +21,7 @@ public class JpaAuditConfig {
 		return () -> {
 			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-			if (authentication == null || !authentication.isAuthenticated()) {
+			if (authentication == null || !authentication.isAuthenticated() || isAnonymous(authentication)) {
 				return Optional.empty();
 			}
 
@@ -29,4 +30,14 @@ public class JpaAuditConfig {
 			return Optional.ofNullable(user.id());
 		};
 	}
+
+	/**
+	 * note : anonymous 객체 필터링을 역할
+	 * @param authentication
+	 * @return
+	 */
+	private boolean isAnonymous(Authentication authentication) {
+		return authentication instanceof AnonymousAuthenticationToken;
+	}
+
 }

--- a/src/main/java/com/kdt/instakyuram/security/WebSecurityConfigure.java
+++ b/src/main/java/com/kdt/instakyuram/security/WebSecurityConfigure.java
@@ -1,10 +1,13 @@
 
 package com.kdt.instakyuram.security;
 
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.*;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -85,7 +88,7 @@ public class WebSecurityConfigure {
 
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
-		return web -> web.ignoring().antMatchers("/static/**", "/templates/**");
+		return web -> web.ignoring().antMatchers("/css/**", "/js/**", "/webjars/**", "/images/**");
 	}
 
 	@Bean

--- a/src/test/java/com/kdt/instakyuram/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/domain/MemberRepositoryTest.java
@@ -33,11 +33,14 @@ class MemberRepositoryTest {
 	@DisplayName("Auditing 테스트 (createdBy, updatedBy 는 null 이 들어갑니다.)")
 	void testSave() {
 		//given
+		String username = "username";
 		Member member = Member.builder()
-			.username("programmer")
-			.email("programmer@programmers.com")
+			.username(username)
+			.email(username+"@programmers.com")
+			.name("program")
 			.password("rlaRla123!!")
 			.phoneNumber("01012341234")
+			.introduction("")
 			.build();
 
 		//when


### PR DESCRIPTION
✅  작업 단위

- [IK-217] develop branch 수정

## 🤔 고민 했던 부분

- 회원 생성 시 audit 쪽에 castException 버그 수정 [토큰 문제]
- Member 통합 테스트 + @WithMock 애너테이션 사용시 castException 버그 수정 [토큰 문제]
  - 전반적으로 auditing 에 security context를 사용하여 createdBy UpdatedBy를 하는 부분에서 인증 토큰들이 객체 유형이 달라 castException이 발생하고 있습니다.
  - **모의 데이터를 저장하는 단계(persist, save)** 와 **통합테스트**를 할 떄 @WithMockUser를 함께 사용한다면 ‼️ 데이터를 영속화해서 셋팅하기 전에 해당 코드를 한번 실행해 주시면 됩니다!! (이해가 안되시면 따로 dm 하시면 될 것 같습니당.)
```java
	/**
	 * note : 필요한 데이터를 저장할 때, jpaAudit이 동작하게 된다 (통합테스트에서만)
	 *   @WithMockUser("MEMBER") 사용시 src 내부에 jpaAudit 부분에 castException이 난다.
	 *   만약 임시 데이터를 사용하기 위해서는 해당 메소드를 한번 호출하면 해결된다.
	 */
	private void setMockAnonymousAuthenticationToken() {
		SimpleGrantedAuthority role_anonymous = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
		List<GrantedAuthority> authorities = new ArrayList<>();
		authorities.add(role_anonymous);
		Authentication authentication = new AnonymousAuthenticationToken("anonymous", "anonymous", authorities);

		SecurityContext context = SecurityContextHolder.createEmptyContext();
		context.setAuthentication(authentication);
		SecurityContextHolder.setContext(context);
	}
```


## 🔊 HELP !!
- 

[IK-217]: https://insta-kkyu.atlassian.net/browse/IK-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ