### PR TITLE
[Ik-225] JWTAuthenticationFilter 리팩토링

### DIFF
--- a/src/main/java/com/kdt/instakyuram/config/JpaAuditConfig.java
+++ b/src/main/java/com/kdt/instakyuram/config/JpaAuditConfig.java
@@ -27,7 +27,7 @@ public class JpaAuditConfig {
 
 			JwtAuthentication user = (JwtAuthentication)authentication.getPrincipal();
 
-			return Optional.ofNullable(user.id());
+			return Optional.ofNullable(user.id().toString());
 		};
 	}
 

--- a/src/main/java/com/kdt/instakyuram/follow/controller/FollowRestController.java
+++ b/src/main/java/com/kdt/instakyuram/follow/controller/FollowRestController.java
@@ -23,17 +23,17 @@ public class FollowRestController {
 	@GetMapping("/{memberId}")
 	public ApiResponse<Boolean> isFollowed(@AuthenticationPrincipal JwtAuthentication auth,
 		@PathVariable Long memberId) {
-		return new ApiResponse<>(followService.isFollowed(Long.parseLong(auth.id()), memberId));
+		return new ApiResponse<>(followService.isFollowed(auth.id(), memberId));
 	}
 
 	@GetMapping("/follow/{memberId}")
 	public ApiResponse<Boolean> follow(@AuthenticationPrincipal JwtAuthentication auth, @PathVariable Long memberId) {
-		return new ApiResponse<>(followService.follow(Long.valueOf(auth.id()), memberId));
+		return new ApiResponse<>(followService.follow(auth.id(), memberId));
 	}
 
 	@GetMapping("/unfollow/{memberId}")
 	public ApiResponse<Boolean> unfollow(@AuthenticationPrincipal JwtAuthentication auth, @PathVariable Long memberId) {
-		followService.unFollow(Long.valueOf(auth.id()), memberId);
+		followService.unFollow(auth.id(), memberId);
 		return new ApiResponse<>(true);
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/member/controller/MemberController.java
+++ b/src/main/java/com/kdt/instakyuram/member/controller/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController {
 		MemberResponse foundMember = memberService.findByUsername(username);
 
 		if(auth != null) {
-			model.addAttribute("auth", Long.valueOf(auth.id()).equals(foundMember.id()));
+			model.addAttribute("auth", auth.id().equals(foundMember.id()));
 		}
 		model.addAttribute("thumbnails", postGiver.findPostThumbnailsByMemberId(foundMember.id()));
 		model.addAttribute("profileInfo", profileService.findProfileInfoByUsername(username));

--- a/src/main/java/com/kdt/instakyuram/member/dto/MemberResponse.java
+++ b/src/main/java/com/kdt/instakyuram/member/dto/MemberResponse.java
@@ -16,7 +16,7 @@ public record MemberResponse(
 		String username) {
 	}
 
-	public record SigninResponse(Long id, String username, String accessToken, String refreshToken) {
+	public record SigninResponse(Long id, String username, String accessToken, String refreshToken, String[] roles) {
 	}
 
 	public record MemberListViewResponse(Long id, String username, String name) {

--- a/src/main/java/com/kdt/instakyuram/member/service/MemberService.java
+++ b/src/main/java/com/kdt/instakyuram/member/service/MemberService.java
@@ -107,11 +107,11 @@ public class MemberService implements MemberGiver {
 			throw new NotFoundException("유저 정보가 일치하지 않습니다.");
 		}
 		String[] roles = {String.valueOf(Role.MEMBER)};
-		String accessToken = jwt.generateAccessToken(Jwt.Claims.from(foundMember.getId().toString(), roles));
+		String accessToken = jwt.generateAccessToken(foundMember.getId(), roles);
 		String refreshToken = jwt.generateRefreshToken();
 		tokenService.save(refreshToken, foundMember.getId());
 
-		return new MemberResponse.SigninResponse(foundMember.getId(), username, accessToken, refreshToken);
+		return new MemberResponse.SigninResponse(foundMember.getId(), username, accessToken, refreshToken, roles);
 	}
 
 	public Long countMyFollowing(Long memberId) {

--- a/src/main/java/com/kdt/instakyuram/post/controller/PostImageRequest.java
+++ b/src/main/java/com/kdt/instakyuram/post/controller/PostImageRequest.java
@@ -1,0 +1,4 @@
+package com.kdt.instakyuram.post.controller;
+
+public record PostImageRequest() {
+}

--- a/src/main/java/com/kdt/instakyuram/security/jwt/JwtAuthentication.java
+++ b/src/main/java/com/kdt/instakyuram/security/jwt/JwtAuthentication.java
@@ -3,10 +3,10 @@ package com.kdt.instakyuram.security.jwt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.logging.log4j.util.Strings.isNotEmpty;
 
-public record JwtAuthentication(String token, String id) {
+public record JwtAuthentication(String token, Long id) {
 	public JwtAuthentication {
 		checkArgument(isNotEmpty(token), "access token must be provided");
-		checkArgument(isNotEmpty(id), "id must be provided");
+		checkArgument(id != null, "id must be provided");
 	}
 
 }

--- a/src/main/java/com/kdt/instakyuram/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kdt/instakyuram/security/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,8 @@
 package com.kdt.instakyuram.security.jwt;
 
-import static org.apache.logging.log4j.util.Strings.isNotEmpty;
-
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -17,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -44,53 +39,54 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().endsWith("/api/members/signup") || request.getRequestURI()
+			.endsWith("/api/members/signin") || SecurityContextHolder.getContext().getAuthentication() != null;
+	}
+
+	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 		try {
-			String accessToken = getAccessToken(request);
-			try {
-				Jwt.Claims claims = verify(accessToken);
-				JwtAuthenticationToken authenticationToken = decodeClaims(claims, request, accessToken);
-				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-				this.log.info("set Authentication");
-			} catch (TokenExpiredException e) {
-				this.log.warn(e.getMessage());
-				String refreshToken = getRefreshToken(request);
-				try {
-					if (isValidRefreshToken(refreshToken, accessToken)) {
-						String reIssuedAccessToken = accessTokenReIssue(accessToken);
-						Jwt.Claims reIssuedClaims = verify(reIssuedAccessToken);
-						SecurityContextHolder.getContext()
-							.setAuthentication(decodeClaims(reIssuedClaims, request, reIssuedAccessToken));
-						response.addCookie(new Cookie(accessTokenHeader, reIssuedAccessToken));
-					}
-				} catch (JwtRefreshTokenNotFoundException notFoundException) {
-					this.log.warn(notFoundException.getMessage());
-				}
-			} catch (JWTVerificationException e) {
-				this.log.warn(e.getMessage());
-			}
-		} catch (JwtAccessTokenNotFoundException | TokenExpiredException e) {
+			authenticate(getAccessToken(request), request, response);
+		} catch (JwtTokenNotFoundException e) {
 			this.log.warn(e.getMessage());
 		}
 		filterChain.doFilter(request, response);
 	}
 
-	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-		return request.getRequestURI().endsWith("/api/members/signup") || request.getRequestURI()
-			.endsWith("/api/members/signin") || SecurityContextHolder.getContext().getAuthentication() != null;
+	private String getAccessToken(HttpServletRequest request) {
+		if (request.getCookies() != null) {
+			return Arrays.stream(request.getCookies())
+				.filter(cookie -> cookie.getName().equals(this.accessTokenHeader))
+				.findFirst()
+				.map(Cookie::getValue)
+				.orElseThrow(() -> new JwtAccessTokenNotFoundException("AccessToken is not found"));
+		} else {
+			throw new JwtAccessTokenNotFoundException("AccessToken is not found.");
+		}
 	}
 
-	private String accessTokenReIssue(String accessToken) {
-		return jwt.generateAccessToken(this.jwt.decode(accessToken));
+	private void authenticate(String accessToken, HttpServletRequest request, HttpServletResponse response) {
+		try {
+			Jwt.Claims claims = verify(accessToken);
+			JwtAuthenticationToken authentication = createAuthenticationToken(claims, request, accessToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			this.log.info("set Authentication");
+
+		} catch (TokenExpiredException exception) {
+			this.log.warn(exception.getMessage());
+			refreshAuthentication(accessToken, request, response);
+		} catch (JWTVerificationException exception) {
+			log.warn(exception.getMessage());
+		}
 	}
 
-	private JwtAuthenticationToken decodeClaims(Jwt.Claims claims, HttpServletRequest request, String accessToken) {
-		String username = claims.userId;
-		List<GrantedAuthority> authorities = getAuthorities(claims);
-		if (isNotEmpty(username) && !authorities.isEmpty()) {
-			JwtAuthentication authentication = new JwtAuthentication(accessToken, username);
+	private JwtAuthenticationToken createAuthenticationToken(Jwt.Claims claims, HttpServletRequest request,
+		String accessToken) {
+		List<GrantedAuthority> authorities = this.jwt.getAuthorities(claims);
+		if (claims.memberId != null && !authorities.isEmpty()) {
+			JwtAuthentication authentication = new JwtAuthentication(accessToken, claims.memberId);
 			JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authentication, null, authorities);
 			authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
@@ -100,49 +96,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 	}
 
-	private boolean isValidRefreshToken(String refreshToken, String accessToken) {
-		TokenResponse foundRefreshToken = this.tokenService.findByToken(refreshToken);
-		String username = this.jwt.decode(accessToken).userId;
-		if (username.equals(foundRefreshToken.userId())) {
-			try {
-				this.jwt.verify(foundRefreshToken.refreshToken());
-			} catch (JWTVerificationException e) {
-				this.log.warn(e.getMessage());
-				return false;
+	private void refreshAuthentication(String accessToken, HttpServletRequest request, HttpServletResponse response) {
+		try {
+			String refreshToken = getRefreshToken(request);
+			if (isValidRefreshToken(refreshToken, accessToken)) {
+				String reIssuedAccessToken = accessTokenReIssue(accessToken);
+				Jwt.Claims reIssuedClaims = verify(reIssuedAccessToken);
+				JwtAuthenticationToken authentication = createAuthenticationToken(reIssuedClaims, request,
+					reIssuedAccessToken);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+				response.addCookie(new Cookie(accessTokenHeader, reIssuedAccessToken));
+			} else {
+				log.warn("refreshToken expired");
 			}
-		}
-		return true;
-	}
-
-	private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {
-		String[] roles = claims.roles;
-
-		return roles == null || roles.length == 0
-			? Collections.emptyList()
-			: Arrays.stream(roles)
-			.map(SimpleGrantedAuthority::new)
-			.collect(Collectors.toList());
-	}
-
-	private Jwt.Claims verify(String token) {
-		return jwt.verify(token);
-	}
-
-	private String getAccessToken(HttpServletRequest request) {
-		if (request.getCookies() != null) {
-			String accessToken = Arrays.stream(request.getCookies())
-				.filter(cookie -> cookie.getName().equals(this.accessTokenHeader))
-				.findFirst()
-				.map(Cookie::getValue)
-				.orElseThrow(JwtAccessTokenNotFoundException::new);
-			try {
-				tokenService.findByToken(accessToken);
-				throw new TokenExpiredException("already signed out token");
-			} catch (JwtTokenNotFoundException e) {
-				return accessToken;
-			}
-		} else {
-			throw new JwtAccessTokenNotFoundException("AccessToken is not found.");
+		} catch (JwtTokenNotFoundException | JWTVerificationException e) {
+			this.log.warn(e.getMessage());
 		}
 	}
 
@@ -156,5 +124,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		} else {
 			throw new JwtRefreshTokenNotFoundException();
 		}
+	}
+
+	private boolean isValidRefreshToken(String refreshToken, String accessToken) {
+		try {
+			TokenResponse foundRefreshToken = this.tokenService.findByToken(refreshToken);
+			Long memberId = this.jwt.decode(accessToken).memberId;
+			if (memberId.equals(foundRefreshToken.memberId())) {
+				this.jwt.verify(foundRefreshToken.token());
+
+				return true;
+			}
+		} catch (JwtRefreshTokenNotFoundException | JWTVerificationException e) {
+			log.warn(e.getMessage());
+
+			return false;
+		}
+		return false;
+	}
+
+	private String accessTokenReIssue(String accessToken) {
+		return jwt.generateAccessToken(this.jwt.decode(accessToken));
+	}
+
+	private Jwt.Claims verify(String token) {
+		return jwt.verify(token);
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/token/domain/Token.java
+++ b/src/main/java/com/kdt/instakyuram/token/domain/Token.java
@@ -12,31 +12,31 @@ import com.kdt.instakyuram.common.BaseEntity;
 public class Token extends BaseEntity {
 
 	@Id
-	private String refreshToken;
+	private String token;
 
-	private Long userId;
+	private Long memberId;
 
 	protected Token() {
 	}
 
-	public Token(String refreshToken, Long userId) {
-		this.refreshToken = refreshToken;
-		this.userId = userId;
+	public Token(String token, Long memberId) {
+		this.token = token;
+		this.memberId = memberId;
 	}
 
-	public String getRefreshToken() {
-		return refreshToken;
+	public String token() {
+		return token;
 	}
 
-	public Long getUserId() {
-		return userId;
+	public Long getMemberId() {
+		return memberId;
 	}
 
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-			.append("refreshToken", refreshToken)
-			.append("userId", userId)
+			.append("token", token)
+			.append("memberId", memberId)
 			.append("createdAt", super.getCreatedAt())
 			.append("updatedAt", super.getUpdatedAt())
 			.append("createdBy", super.getCreatedBy())

--- a/src/main/java/com/kdt/instakyuram/token/dto/TokenResponse.java
+++ b/src/main/java/com/kdt/instakyuram/token/dto/TokenResponse.java
@@ -1,4 +1,4 @@
 package com.kdt.instakyuram.token.dto;
 
-public record TokenResponse(String refreshToken, String userId) {
+public record TokenResponse(String token, Long memberId) {
 }

--- a/src/main/java/com/kdt/instakyuram/token/service/TokenService.java
+++ b/src/main/java/com/kdt/instakyuram/token/service/TokenService.java
@@ -19,11 +19,11 @@ public class TokenService {
 	public TokenResponse findByToken(String token) {
 		Token foundToken = tokenRepository.findById(token).orElseThrow(JwtTokenNotFoundException::new);
 
-		return new TokenResponse(foundToken.getRefreshToken(), foundToken.getUserId().toString());
+		return new TokenResponse(foundToken.token(), foundToken.getMemberId());
 	}
 
 	public String save(String refreshToken, Long userId) {
-		return tokenRepository.save(new Token(refreshToken, userId)).getRefreshToken();
+		return tokenRepository.save(new Token(refreshToken, userId)).token();
 	}
 
 	public void deleteByToken(String token) {

--- a/src/test/java/com/kdt/instakyuram/configure/TestJpaAuditConfig.java
+++ b/src/test/java/com/kdt/instakyuram/configure/TestJpaAuditConfig.java
@@ -26,7 +26,7 @@ public class TestJpaAuditConfig {
 
 			JwtAuthentication user = (JwtAuthentication)authentication.getPrincipal();
 
-			return Optional.ofNullable(user.id());
+			return Optional.ofNullable(user.id().toString());
 		};
 	}
 }

--- a/src/test/java/com/kdt/instakyuram/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/controller/MemberControllerTest.java
@@ -206,7 +206,8 @@ class MemberControllerTest {
 			member.getId(),
 			member.getUsername(),
 			accessToken,
-			refreshToken
+			refreshToken,
+			new String[] {String.valueOf(Role.MEMBER)}
 		);
 
 		String request = objectMapper.writeValueAsString(signinRequest);

--- a/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
@@ -277,7 +277,7 @@ class MemberServiceTest {
 
 		given(passwordEncoder.matches(request.password(), member.getPassword())).willReturn(true);
 		given(memberRepository.findByUsername(request.username())).willReturn(Optional.of(member));
-		given(jwt.generateAccessToken(any(Jwt.Claims.class))).willReturn(accessToken);
+		given(jwt.generateAccessToken(any(Long.class), any(String[].class))).willReturn(accessToken);
 		given(jwt.generateRefreshToken()).willReturn(refreshToken);
 		given(tokenService.save(refreshToken, member.getId())).willReturn(refreshToken);
 
@@ -287,7 +287,7 @@ class MemberServiceTest {
 		//then
 		verify(passwordEncoder, times(1)).matches(request.password(), member.getPassword());
 		verify(memberRepository, times(1)).findByUsername(request.username());
-		verify(jwt, times(1)).generateAccessToken(any(Jwt.Claims.class));
+		verify(jwt, times(1)).generateAccessToken(any(Long.class), any(String[].class));
 		verify(jwt, times(1)).generateRefreshToken();
 		verify(tokenService, times(1)).save(refreshToken, member.getId());
 

--- a/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
@@ -36,6 +36,7 @@ import com.kdt.instakyuram.member.domain.MemberRepository;
 import com.kdt.instakyuram.member.dto.MemberConverter;
 import com.kdt.instakyuram.member.dto.MemberRequest;
 import com.kdt.instakyuram.member.dto.MemberResponse;
+import com.kdt.instakyuram.security.Role;
 import com.kdt.instakyuram.security.jwt.Jwt;
 import com.kdt.instakyuram.token.service.TokenService;
 
@@ -261,6 +262,7 @@ class MemberServiceTest {
 			"");
 		String accessToken = "accessToken";
 		String refreshToken = "refreshToken";
+		String[] roles = {String.valueOf(Role.MEMBER)};
 		MemberRequest.SigninRequest request = new MemberRequest.SigninRequest(
 			member.getUsername(),
 			"123456789"
@@ -269,7 +271,8 @@ class MemberServiceTest {
 			member.getId(),
 			member.getUsername(),
 			accessToken,
-			refreshToken
+			refreshToken,
+			roles
 		);
 
 		given(passwordEncoder.matches(request.password(), member.getPassword())).willReturn(true);


### PR DESCRIPTION
## ✅  작업 단위

### 커밋 분리에 실패했습니다;;; 죄송함다

- JWT 로그인 시 principal에 들어가는 토큰하고 생성되는 토큰하고 달랐던 버그를 수정했습니다.
- JWT Authentication Token에는 id값이 String 보다 Long이 적합하다고 판단되어 변경했습니다.
- token 테이블의 refreshToken 컬럼은 액세스 토큰과 리프레쉬 토큰 공용으로 사용하므로 token으로 네이밍 변경했습니다.
- JWTAuthenticationFilter로직을 전체적으로 정리했습니다.

## 🤔 고민 했던 부분

- JWT 로그인 시 principal에 들어가는 토큰하고 생성되는 토큰하고 달랐던 버그를 수정했습니다.
  - 로그인 시 Authentication을 바로 설정해줘야하는데 설정하지 않았습니다. 이러한 문제 때문에 인증이 필요한 api 접근 시 토큰을 재 발급 받게 되어 로그인할때와 토큰이 달랐던 문제였습니다.

## 🔊 HELP !!

- 