### PR TITLE
[IK-201] 댓글 조회 기능 구현, 댓글 도메인에 시큐리티 일괄 적용

### DIFF
--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -29,9 +29,12 @@ public class CommentRestController {
 	}
 
 	@PostMapping
-	public ApiResponse<CommentResponse> create(@RequestBody CommentRequest.CreateRequest request) {
+	public ApiResponse<CommentResponse> create(
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@RequestBody CommentRequest.CreateRequest request
+	) {
 		CommentResponse commentResponse = commentService.create(
-			request.postId(), request.memberId(), request.content()
+			request.postId(), authentication.id(), request.content()
 		);
 
 		return new ApiResponse<>(commentResponse);
@@ -39,19 +42,19 @@ public class CommentRestController {
 
 	@DeleteMapping("/{id}")
 	public void delete(
-		@PathVariable Long id,
-		@RequestBody CommentRequest.DeleteRequest request
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long id
 	) {
-		commentService.delete(id, request.memberId());
+		commentService.delete(id, authentication.id());
 	}
 
 	@PostMapping("/{id}/like")
 	public ApiResponse<CommentResponse.LikeResponse> like(
-		@PathVariable Long id,
-		@RequestBody CommentRequest.LikeRequest request
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long id
 	) {
 		CommentResponse.LikeResponse commentResponse = commentService.like(
-			id, request.memberId()
+			id, authentication.id()
 		);
 
 		return new ApiResponse<>(commentResponse);
@@ -59,11 +62,11 @@ public class CommentRestController {
 
 	@PostMapping("{id}/unlike")
 	public ApiResponse<CommentResponse.LikeResponse> unlike(
-		@PathVariable Long id,
-		@RequestBody CommentRequest.LikeRequest request
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long id
 	) {
 		CommentResponse.LikeResponse commentResponse = commentService.unlike(
-			id, request.memberId()
+			id, authentication.id()
 		);
 
 		return new ApiResponse<>(commentResponse);

--- a/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
+++ b/src/main/java/com/kdt/instakyuram/comment/controller/CommentRestController.java
@@ -1,16 +1,22 @@
 package com.kdt.instakyuram.comment.controller;
 
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt.instakyuram.comment.dto.CommentFindAllResponse;
 import com.kdt.instakyuram.comment.dto.CommentRequest;
 import com.kdt.instakyuram.comment.dto.CommentResponse;
 import com.kdt.instakyuram.comment.service.CommentService;
 import com.kdt.instakyuram.common.ApiResponse;
+import com.kdt.instakyuram.security.jwt.JwtAuthentication;
 
 @RestController
 @RequestMapping("/api/comments")
@@ -61,5 +67,15 @@ public class CommentRestController {
 		);
 
 		return new ApiResponse<>(commentResponse);
+	}
+
+	@GetMapping("/post/{postId}")
+	public ApiResponse<List<CommentFindAllResponse>> findAll(
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long postId
+	) {
+		List<CommentFindAllResponse> comments = commentService.findAll(postId, authentication.id());
+
+		return new ApiResponse<>(comments);
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepository.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.kdt.instakyuram.post.domain.Post;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
 	@Query("SELECT c FROM Comment c JOIN FETCH c.member m WHERE c.post.id = :postId")
 	List<Comment> findAllByPostId(Long postId);

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepositoryCustom.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.kdt.instakyuram.comment.domain;
+
+import java.util.List;
+
+import com.kdt.instakyuram.comment.dto.CommentFindAllResponse;
+
+public interface CommentRepositoryCustom {
+
+	List<CommentFindAllResponse> findAllByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/kdt/instakyuram/comment/domain/CommentRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.kdt.instakyuram.comment.domain;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.stereotype.Repository;
+
+import com.kdt.instakyuram.comment.dto.CommentFindAllResponse;
+
+@Repository
+public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
+
+	private final EntityManager em;
+
+	public CommentRepositoryCustomImpl(EntityManager em) {
+		this.em = em;
+	}
+
+	// TODO Criteria 로 변환 필요
+	@Override
+	public List<CommentFindAllResponse> findAllByPostIdAndMemberId(Long postId, Long memberId) {
+		String sql = "SELECT new com.kdt.instakyuram.comment.dto.CommentFindAllResponse(c.id, c.post.id, c.content, c.member.id, m.username, count(cl.id), case when cl.member.id = :memberId then true else false end)"
+			+ " FROM Comment c"
+			+ " INNER JOIN Member m ON c.member.id = m.id"
+			+ " LEFT OUTER JOIN CommentLike cl ON c.id = cl.comment.id"
+			+ " WHERE c.post.id = :postId"
+			+ " GROUP BY c.id, c.post.id, c.content, c.member.id, m.username, case when cl.member.id = :memberId then true else false end";
+
+		return em.createQuery(sql, CommentFindAllResponse.class)
+			.setParameter("postId", postId)
+			.setParameter("memberId", memberId)
+			.getResultList();
+	}
+}

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentFindAllResponse.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentFindAllResponse.java
@@ -1,0 +1,15 @@
+package com.kdt.instakyuram.comment.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CommentFindAllResponse(
+	Long id,
+	Long postId,
+	String content,
+	Long memberId,
+	String username,
+	long likes,
+	boolean isLiked
+) {
+}

--- a/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
+++ b/src/main/java/com/kdt/instakyuram/comment/dto/CommentRequest.java
@@ -2,12 +2,6 @@ package com.kdt.instakyuram.comment.dto;
 
 public record CommentRequest() {
 
-	public record CreateRequest(Long postId, Long memberId, String content) {
-	}
-
-	public record LikeRequest(Long memberId) {
-	}
-
-	public record DeleteRequest(Long memberId) {
+	public record CreateRequest(Long postId, String content) {
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kdt.instakyuram.comment.domain.Comment;
 import com.kdt.instakyuram.comment.domain.CommentRepository;
 import com.kdt.instakyuram.comment.dto.CommentConverter;
+import com.kdt.instakyuram.comment.dto.CommentFindAllResponse;
 import com.kdt.instakyuram.comment.dto.CommentResponse;
 import com.kdt.instakyuram.exception.EntityNotFoundException;
 import com.kdt.instakyuram.exception.ErrorCode;
@@ -16,6 +17,7 @@ import com.kdt.instakyuram.member.dto.MemberResponse;
 import com.kdt.instakyuram.member.service.MemberGiver;
 import com.kdt.instakyuram.post.domain.Post;
 
+@Transactional(readOnly = true)
 @Service
 public class CommentService implements CommentGiver {
 
@@ -106,5 +108,9 @@ public class CommentService implements CommentGiver {
 		return commentRepository.findByPostIn(posts).stream()
 			.map(commentConverter::toResponse)
 			.toList();
+	}
+
+	public List<CommentFindAllResponse> findAll(Long postId, Long memberId) {
+		return commentRepository.findAllByPostIdAndMemberId(postId, memberId);
 	}
 }

--- a/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
+++ b/src/main/java/com/kdt/instakyuram/comment/service/CommentService.java
@@ -91,6 +91,7 @@ public class CommentService implements CommentGiver {
 			.toList();
 	}
 
+	@Transactional
 	@Override
 	public void delete(Long id) {
 		commentRepository.findById(id)

--- a/src/main/resources/db/seed/R__022_Seed_comment_like.sql
+++ b/src/main/resources/db/seed/R__022_Seed_comment_like.sql
@@ -1,0 +1,23 @@
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (1, 3, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (1, 4, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (1, 5, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (1, 3, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (2, 2, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (2, 4, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (2, 5, now(), 'test', now(), 'test');
+
+INSERT IGNORE INTO comment_like(comment_id, member_id, created_at, created_by, updated_at, updated_by)
+VALUES (3, 1, now(), 'test', now(), 'test');


### PR DESCRIPTION
## ✅  작업 단위

### [[IK-201] feat: 댓글 조회 기능 구현 (Native Query)](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/a9d3c0e54306d3c814c65ece3189de6db0453522)
- 댓글 전체 조회 NativeQuery로 작성하였습니다.

### [[IK-201] refactor: AuthenticationPrincipal 일괄 적용, delete() - 트랜잭션 추가](https://github.com/prgrms-be-devcourse/BE-02-Instakyuram/commit/10219d750c5e8a7558f30d3dc129ff6e0f547723)
- AuthenticationPrincipal 일괄 적용
- 서비스단 delete 메소드에 Transaction 빠진것 추가

## 🤔 고민 했던 부분

- Criteria로 해보려다가 시간만 날리고 실패했습니다. 🫠

## 🔊 HELP !!

- 

[IK-201]: https://insta-kkyu.atlassian.net/browse/IK-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IK-201]: https://insta-kkyu.atlassian.net/browse/IK-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ