### PR TITLE
[IK-127] 회원 목록 조회 UI

### DIFF
--- a/src/main/java/com/kdt/instakyuram/member/controller/MemberController.java
+++ b/src/main/java/com/kdt/instakyuram/member/controller/MemberController.java
@@ -43,11 +43,16 @@ public class MemberController {
 
 	//todo: @AuthenticationPrincipal JwtAuthentication member로 요청 id 뽑아내기 -> 테스트 코드 변경
 	@GetMapping
-	public ModelAndView getMembers(@ModelAttribute @Valid PageDto.Request pagingDto) {
+	public ModelAndView getMembers(@ModelAttribute @Valid PageDto.Request pagingDto,
+		@AuthenticationPrincipal JwtAuthentication auth) {
+		if (auth == null) {
+			throw new NotAuthenticationException("로그인을 하셔야 합니다..");
+		}
+
 		Pageable requestPage = pagingDto.getPageable(Sort.by("id").descending());
 
 		return new ModelAndView("member/member-list")
-			.addObject(memberService.findAll(requestPage));
+			.addObject("dto", memberService.findAll(auth.id(), requestPage));
 	}
 
 	@GetMapping("/{username}")

--- a/src/main/java/com/kdt/instakyuram/member/dto/MemberConverter.java
+++ b/src/main/java/com/kdt/instakyuram/member/dto/MemberConverter.java
@@ -1,5 +1,7 @@
 package com.kdt.instakyuram.member.dto;
 
+import java.util.Set;
+
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
@@ -9,11 +11,18 @@ import com.kdt.instakyuram.member.domain.Member;
 @Component
 public class MemberConverter {
 
-	public PageDto.Response<MemberResponse.MemberListViewResponse, Member> toPageResponse(Page<Member> members) {
+	public PageDto.Response<MemberResponse.MemberListViewResponse, Member> toPageResponse(Page<Member> members,
+		Set<Long> authFollowings) {
 		return new PageDto.Response<>(
 			members,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(),
-				member.getName()));
+			member -> MemberResponse.MemberListViewResponse
+				.builder()
+				.id(member.getId())
+				.username(member.getUsername())
+				.name(member.getName())
+				.possibleFollow(!authFollowings.contains(member.getId()))
+				.build()
+		);
 	}
 
 	public MemberResponse toMemberResponse(Member member) {

--- a/src/main/java/com/kdt/instakyuram/member/dto/MemberResponse.java
+++ b/src/main/java/com/kdt/instakyuram/member/dto/MemberResponse.java
@@ -19,7 +19,8 @@ public record MemberResponse(
 	public record SigninResponse(Long id, String username, String accessToken, String refreshToken, String[] roles) {
 	}
 
-	public record MemberListViewResponse(Long id, String username, String name) {
+	@Builder
+	public record MemberListViewResponse(Long id, String username, String name, boolean possibleFollow) {
 	}
 
 	public record ProfileInfoResponse(

--- a/src/main/java/com/kdt/instakyuram/member/service/MemberService.java
+++ b/src/main/java/com/kdt/instakyuram/member/service/MemberService.java
@@ -89,14 +89,16 @@ public class MemberService implements MemberGiver {
 	}
 
 	// todo : 요청한 사용자의 정보는 빼야함! -> 테스트 코드 변경
-	public PageDto.Response<MemberResponse.MemberListViewResponse, Member> findAll(Pageable requestPage) {
+	public PageDto.Response<MemberResponse.MemberListViewResponse, Member> findAll(Long authId, Pageable requestPage) {
 		Page<Member> pagingMembers = memberRepository.findAll(requestPage);
-
 		if (pagingMembers.getContent().isEmpty()) {
 			throw new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND);
 		}
 
-		return memberConverter.toPageResponse(pagingMembers);
+		List<Long> memberIds = pagingMembers.getContent().stream().map(Member::getId).toList();
+		Set<Long> authFollowings = followService.findAuthFollowings(authId, memberIds);
+
+		return memberConverter.toPageResponse(pagingMembers, authFollowings);
 	}
 
 	public List<MemberResponse> findAllFollowing(Long id) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -39,7 +39,7 @@ security:
     client-secret: EENY5W0eegTf1naQB2eDeyCLl5kRS2b8xa5c4qLdS0hmVjtbvo8tOyhPMcAmtPuQ
     accessToken:
       header: atoken
-      expiry-seconds: 60
+      expiry-seconds: 6000000
     refreshToken:
       header: rtoken
-      expiry-seconds: 120
+      expiry-seconds: 6000000

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -40,6 +40,11 @@
                         />
                     </a>
                 </li>
+                <li class="navbar__menu__item">
+                    <a th:href="@{/members/all}">
+                        회원 목록
+                    </a>
+                </li>
                 <li>
                     <a th:href="@{|/members/${username}|}">
                         <img

--- a/src/main/resources/templates/member/member-list.html
+++ b/src/main/resources/templates/member/member-list.html
@@ -2,9 +2,102 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2"
+            crossorigin="anonymous"></script>
     <title>사용자가 팔로잉 할 대상 찾는 사용자 목록</title>
 </head>
 <body>
+<main>
+    <h1> 사용자가 팔로우 할 대상을 찾는 페이지</h1>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th hidden>id</th>
+            <th>username</th>
+            <th>name</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="member : ${dto?.responses}">
+            <td hidden th:text="${member.id()}"></td>
+            <td th:text="${member.username()}" onclick="renderProFile(this)"></td>
+            <td th:text="${member.name()}"></td>
+            <td>
+                <button type="button" class="btn btn-primary" th:if="${member.possibleFollow()}" onclick="follow(this)">팔로우</button>
+                <button type="button" class="btn btn-secondary" th:if="${!member.possibleFollow()}" onclick="unFollow(this)">팔로잉</button>
+            </td>
+        </tr>
+        </tbody>
+    </table>
 
+    <ul class="pagination h-100 justify-content-center align-items-center">
+
+        <li class="page-item " th:if="${dto?.hasPrevious}" id="previous">
+            <a class="page-link"
+               th:href="@{/members(page= ${dto.start -1},size=${10})}"
+               tabindex="-1">Previous</a>
+        </li>
+
+        <li th:class=" 'page-item ' + ${dto?.page == page ? 'active':''} "
+            th:each="page: ${dto?.pageNumbers}">
+            <a class="page-link"
+               th:href="@{/members(page = ${page},size=${10})}">
+                [[${page}]]
+            </a>
+        </li>
+
+        <li class="page-item" th:if="${dto?.hasNext}" id="next">
+            <a class="page-link" th:href="@{/members(page= ${dto.end + 1}
+                ,size=${10})}">
+                Next
+            </a>
+        </li>
+
+    </ul>
+</main>
+<script>
+    function renderProFile(e) {
+        console.log('render profile')
+    }
+
+    function unFollow(my) {
+        console.log('unfollow');
+        let memberId = my.parentNode.parentNode.children[0].innerHTML;
+        fetch('/api/friendships/unfollow/' + memberId, {
+            method: "GET",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify()
+        }).then((response) => {
+            if (!response.ok) {
+                alert(response.json());
+                return;
+            }
+            my.setAttribute("class", "btn btn-primary");
+            my.setAttribute("onclick", "follow(this)");
+            my.innerText="팔로우";
+        })
+    }
+
+    function follow(my) {
+        console.log('follow')
+        let memberId = my.parentNode.parentNode.children[0].innerHTML;
+        fetch('/api/friendships/follow/' + memberId, {
+            method: "GET",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify()
+        }).then((response) => {
+            if (!response.ok) {
+                alert(response.json());
+                return;
+            }
+            my.setAttribute("class", "btn btn-danger");
+            my.setAttribute("onclick", "unFollow(this)");
+            my.innerText="팔로잉";
+        })
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/member/member-list.html
+++ b/src/main/resources/templates/member/member-list.html
@@ -93,7 +93,7 @@
                 alert(response.json());
                 return;
             }
-            my.setAttribute("class", "btn btn-danger");
+            my.setAttribute("class", "btn btn-secondary");
             my.setAttribute("onclick", "unFollow(this)");
             my.innerText="팔로잉";
         })

--- a/src/main/resources/templates/modal/follower-list.html
+++ b/src/main/resources/templates/modal/follower-list.html
@@ -27,7 +27,7 @@
             <td th:text="${follower.username()}" onclick="moveProfile(this)"></td>
             <td th:text="${follower.name()}"></td>
             <td th:if="${!follower.isMe()}">
-                <button class="btn btn-danger" th:if="${follower.isAlsoAuthFollowing()}" onclick="unFollow(this)">
+                <button class="btn btn-secondary" th:if="${follower.isAlsoAuthFollowing()}" onclick="unFollow(this)">
                     unfollow
                 </button>
                 <button class="btn btn-primary" th:if="${!follower.isAlsoAuthFollowing()}" onclick="follow(this)">
@@ -61,7 +61,7 @@
             }
             my.setAttribute("class", "btn btn-primary");
             my.setAttribute("onclick", "follow(this)");
-            my.innerText="follow";
+            my.innerText="팔로우";
         })
     }
 
@@ -77,9 +77,9 @@
                 alert(response.json());
                 return;
             }
-            my.setAttribute("class", "btn btn-danger");
+            my.setAttribute("class", "btn btn-secondary");
             my.setAttribute("onclick", "unFollow(this)");
-            my.innerText="unfollow";
+            my.innerText="팔로잉";
         })
     }
 
@@ -119,13 +119,13 @@
             let button = document.createElement('button');
 
             if (item.isAlsoAuthFollowing) {
-                button.setAttribute("class", "btn btn-danger")
+                button.setAttribute("class", "btn btn-secondary")
                 button.setAttribute("onclick", "unFollow(this)");
-                button.innerText = 'unfollow';
+                button.innerText = '팔로잉';
             } else {
                 button.setAttribute("class", "btn btn-primary")
                 button.setAttribute("onclick", "follow(this)");
-                button.innerText = 'follow';
+                button.innerText = '팔로우';
             }
 
             td.appendChild(button);

--- a/src/main/resources/templates/modal/following-list.html
+++ b/src/main/resources/templates/modal/following-list.html
@@ -27,11 +27,11 @@
             <td th:text="${following.username()}" onclick="moveProfile(this)"></td>
             <td th:text="${following.name()}"></td>
             <td th:if="${!following.isMe()}">
-                <button class="btn btn-danger" th:if="${following.isAlsoAuthFollowing()}" onclick="unFollow(this)">
-                    unfollow
+                <button class="btn btn-secondary" th:if="${following.isAlsoAuthFollowing()}" onclick="unFollow(this)">
+                    팔로잉
                 </button>
                 <button class="btn btn-primary" th:if="${!following.isAlsoAuthFollowing()}" onclick="follow(this)">
-                    follow
+                    팔로우
                 </button>
             </td>
         </tr>
@@ -61,7 +61,7 @@
             }
             my.setAttribute("class", "btn btn-primary");
             my.setAttribute("onclick", "follow(this)");
-            my.innerText="follow";
+            my.innerText="팔로우";
         })
     }
 
@@ -77,9 +77,9 @@
                 alert(response.json());
                 return;
             }
-            my.setAttribute("class", "btn btn-danger");
+            my.setAttribute("class", "btn btn-secondary");
             my.setAttribute("onclick", "unFollow(this)");
-            my.innerText="unfollow";
+            my.innerText="팔로잉";
         })
     }
 
@@ -119,13 +119,13 @@
             let button = document.createElement('button');
 
             if (item.isAlsoAuthFollowing) {
-                button.setAttribute("class", "btn btn-danger")
+                button.setAttribute("class", "btn btn-secondary")
                 button.setAttribute("onclick", "unFollow(this)");
-                button.innerText = 'unfollow';
+                button.innerText = '팔로잉';
             } else {
                 button.setAttribute("class", "btn btn-primary")
                 button.setAttribute("onclick", "follow(this)");
-                button.innerText = 'follow';
+                button.innerText = '팔로우';
             }
 
             td.appendChild(button);

--- a/src/main/resources/templates/modal/following-list.html
+++ b/src/main/resources/templates/modal/following-list.html
@@ -65,7 +65,7 @@
         })
     }
 
-    function follow(my, e) {
+    function follow(my) {
         console.log('follow')
         let memberId = my.parentNode.parentNode.children[0].innerHTML;
         fetch('/api/friendships/follow/' + memberId, {

--- a/src/test/java/com/kdt/instakyuram/member/controller/MemberControllerIntegrationTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/controller/MemberControllerIntegrationTest.java
@@ -54,23 +54,24 @@ public class MemberControllerIntegrationTest {
 	private ObjectMapper mapper;
 
 	@Test
-	@WithMockUser("MEMBER")
 	@Transactional
 	@DisplayName("사용자가 목록을 조회한다.")
 	void testGetMembers() throws Exception {
 		//given
+		Long authId=1L;
+		setMockingAuthentication(authId);
 		int requestPage = 2;
 		int requestSize = 5;
 		String htmlTittleContent = "사용자가 팔로잉 할 대상 찾는 사용자 목록";
 
 		PageDto.Request request = new PageDto.Request(requestPage, requestSize);
 		Pageable pageRequest = new PageDto.Request(requestPage, requestSize).getPageable(Sort.by("id"));
-		setMockAnonymousAuthenticationToken();
 		List<Member> members = getMembersForOffSetPaging();
 		PageImpl<Member> pagingMembers = new PageImpl<>(members, pageRequest, members.size());
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> pageResponse = new PageDto.Response<>(
 			pagingMembers,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName())
+			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName(),
+				true)
 		);
 
 		//when
@@ -85,10 +86,11 @@ public class MemberControllerIntegrationTest {
 	}
 
 	@Test
-	@WithMockUser("MEMBER")
 	@DisplayName("사용자 uri 를 조작할 때, 멤버가 없는 없는 페이지 번호를 요청한다면 오류페이지로 전환한다.")
 	void testFailGetMembers() throws Exception {
 		// given
+		Long authId=1L;
+		setMockingAuthentication(authId);
 		int requestPage = 100;
 		int requestSize = 5;
 		String errorPageTitle = "오류 페이지";
@@ -99,7 +101,8 @@ public class MemberControllerIntegrationTest {
 		PageImpl<Member> pagingMembers = new PageImpl<>(members, pageRequest, members.size());
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> pageResponse = new PageDto.Response<>(
 			pagingMembers,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName())
+			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName(),
+				true)
 		);
 
 		//when

--- a/src/test/java/com/kdt/instakyuram/member/dto/MemberConverterTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/dto/MemberConverterTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import org.assertj.core.api.Assertions;
@@ -41,13 +41,14 @@ class MemberConverterTest {
 		PageImpl<Member> pagingMembers = new PageImpl<>(members, pageRequest, members.size());
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> expectedResponses = new PageDto.Response<>(
 			pagingMembers,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName())
+			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName(),
+				true)
 		);
 		List<MemberResponse.MemberListViewResponse> expectedContents = expectedResponses.getResponses();
 
 		//when
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> responses = memberConverter.toPageResponse(
-			pagingMembers);
+			pagingMembers, Set.of());
 		AtomicInteger index = new AtomicInteger();
 
 		//then
@@ -102,9 +103,10 @@ class MemberConverterTest {
 		String phoneNumber = "01012345678";
 		String emailPostfix = "@programmers.co.kr";
 
-		IntStream.rangeClosed(1, 3).forEach(
+		LongStream.rangeClosed(1, 3).forEach(
 			number -> {
 				Member member = Member.builder()
+					.id(number)
 					.email((name + number) + emailPostfix)
 					.password(password)
 					.username(name + number)

--- a/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kdt/instakyuram/member/service/MemberServiceTest.java
@@ -70,6 +70,7 @@ class MemberServiceTest {
 	@DisplayName("사용자 목록 조회")
 	void testFindAll() {
 		//given
+		Long authId = 1L;
 		int requestPage = 2;
 		int requestSize = 5;
 
@@ -78,22 +79,23 @@ class MemberServiceTest {
 		PageImpl<Member> pagingMembers = new PageImpl<>(members, pageRequest, members.size());
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> pageResponse = new PageDto.Response<>(
 			pagingMembers,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName())
+			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(),
+				member.getName(), true)
 		);
 		List<Integer> expectedPageNumbers = IntStream.rangeClosed(1, pageResponse.getTotalPage())
 			.boxed()
 			.toList();
 
 		given(memberRepository.findAll(pageRequest)).willReturn(pagingMembers);
-		given(memberConverter.toPageResponse(pagingMembers)).willReturn(pageResponse);
+		given(memberConverter.toPageResponse(pagingMembers, Set.of())).willReturn(pageResponse);
 
 		//when
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> pageMemberResponses = memberService.findAll(
-			pageRequest);
+			authId, pageRequest);
 
 		//then
 		verify(memberRepository, times(1)).findAll(pageRequest);
-		verify(memberConverter, times(1)).toPageResponse(pagingMembers);
+		verify(memberConverter, times(1)).toPageResponse(pagingMembers, Set.of());
 
 		assertThat(pageMemberResponses.getPage()).isEqualTo(requestPage);
 		assertThat(pageMemberResponses.hasPrevious()).isFalse();
@@ -105,6 +107,7 @@ class MemberServiceTest {
 	@DisplayName("사용자 목록 조회에 데이터가 없는 경우 실패한다")
 	void testFailFindAll() {
 		//given
+		Long authId = 1L;
 		int requestPage = 2;
 		int requestSize = 5;
 
@@ -112,7 +115,8 @@ class MemberServiceTest {
 		PageImpl<Member> pagingMembers = new PageImpl<>(List.of(), pageRequest, 0);
 		PageDto.Response<MemberResponse.MemberListViewResponse, Member> pageResponse = new PageDto.Response<>(
 			pagingMembers,
-			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName())
+			member -> new MemberResponse.MemberListViewResponse(member.getId(), member.getUsername(), member.getName(),
+				true)
 		);
 
 		given(memberRepository.findAll(pageRequest)).willReturn(pagingMembers);
@@ -120,7 +124,7 @@ class MemberServiceTest {
 		//when
 		//then
 		assertThatThrownBy(() -> {
-			memberService.findAll(pageRequest);
+			memberService.findAll(authId,pageRequest);
 		}).isInstanceOf(EntityNotFoundException.class);
 	}
 


### PR DESCRIPTION
## ✅  작업 단위

- [IK-127] 회원 목록 조회 UI

## 🤔 고민 했던 부분

- 오프셋 페이징 처리로 했습니다. 
- 나중에 회원 검색으로 대체 될 수 있기 떄문에 오프셋 기반 페이징 처리로 구현했습니다. 
- 커서기반과 비교해서 보여드릴 수 있는 좋은 기회이기도 하기 때문입니다.
- 해당 화면에서 팔로우, 팔로잉이 가능하도록 했습니다.
<img width="1052" alt="스크린샷 2022-06-27 오후 6 45 02" src="https://user-images.githubusercontent.com/67587446/175915705-c41a33fd-e828-41ce-9956-c1d16b5a3409.png">


## 🔊 HELP !!

-

[IK-127]: https://insta-kkyu.atlassian.net/browse/IK-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ